### PR TITLE
use path.join so that pkg could auto detect the proto file.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,9 @@
 
 var protobuf = require('protocol-buffers');
 var fs = require('fs');
+var path = require('path');
 
-var messages = protobuf(fs.readFileSync(__dirname + '/proto/glyphs.proto'));
+var messages = protobuf(fs.readFileSync(path.join(__dirname + '/proto/glyphs.proto')));
 
 function debug(buffer, decode) {
     if (decode) buffer = messages.glyphs.decode(buffer);

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var protobuf = require('protocol-buffers');
 var fs = require('fs');
 var path = require('path');
 
-var messages = protobuf(fs.readFileSync(path.join(__dirname + '/proto/glyphs.proto')));
+var messages = protobuf(fs.readFileSync(path.join(__dirname, './proto/glyphs.proto')));
 
 function debug(buffer, decode) {
     if (decode) buffer = messages.glyphs.decode(buffer);


### PR DESCRIPTION
[pkg](https://github.com/zeit/pkg) could auto package assets if we use `path.join(__dirname, 'aaa.txt')`.

this issue is same as https://github.com/mapbox/node-mbtiles/pull/80